### PR TITLE
Add splash screen

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -59,6 +59,7 @@ export 'resource/styles/app_themes.dart';
 export 'shared_view/app_text_field.dart';
 export 'ui/home/home_page.dart';
 export 'ui/item_detail/item_detail_page.dart';
+export 'ui/splash/splash_page.dart';
 export 'ui/login/login_page.dart';
 export 'ui/main/main_page.dart';
 export 'ui/my_page/my_page_page.dart';

--- a/app/lib/app/my_app.dart
+++ b/app/lib/app/my_app.dart
@@ -85,6 +85,8 @@ class _MyAppState extends BasePageState<MyApp, AppBloc> {
   List<PageRouteInfo> _mapRouteToPageRouteInfo() {
     return widget.initialResource.initialRoutes.map<PageRouteInfo>((e) {
       switch (e) {
+        case InitialAppRoute.splash:
+          return const SplashRoute();
         case InitialAppRoute.login:
           return const LoginRoute();
         case InitialAppRoute.main:

--- a/app/lib/navigation/mapper/app_route_info_mapper.dart
+++ b/app/lib/navigation/mapper/app_route_info_mapper.dart
@@ -9,6 +9,7 @@ class AppRouteInfoMapper extends BaseRouteInfoMapper {
   @override
   PageRouteInfo map(AppRouteInfo appRouteInfo) {
     return appRouteInfo.when(
+      splash: () => const SplashRoute(),
       login: () => const LoginRoute(),
       main: () => const MainRoute(),
       itemDetail: (user) => ItemDetailRoute(user: user),

--- a/app/lib/navigation/routes/app_router.dart
+++ b/app/lib/navigation/routes/app_router.dart
@@ -16,6 +16,7 @@ class AppRouter extends RootStackRouter {
 
   @override
   List<AutoRoute> get routes => [
+        AutoRoute(page: SplashRoute.page, initial: true),
         AutoRoute(page: LoginRoute.page),
         AutoRoute(page: MainRoute.page, children: [
           AutoRoute(

--- a/app/lib/ui/splash/bloc/splash.dart
+++ b/app/lib/ui/splash/bloc/splash.dart
@@ -1,0 +1,3 @@
+export 'splash_bloc.dart';
+export 'splash_event.dart';
+export 'splash_state.dart';

--- a/app/lib/ui/splash/bloc/splash_bloc.dart
+++ b/app/lib/ui/splash/bloc/splash_bloc.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:domain/domain.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../app.dart';
+import 'package:shared/shared.dart';
+import 'splash.dart';
+
+@Injectable()
+class SplashBloc extends BaseBloc<SplashEvent, SplashState> {
+  SplashBloc(this._isLoggedInUseCase) : super(const SplashState()) {
+    on<SplashPageInitiated>(
+      _onSplashPageInitiated,
+      transformer: log(),
+    );
+  }
+
+  final IsLoggedInUseCase _isLoggedInUseCase;
+
+  FutureOr<void> _onSplashPageInitiated(
+    SplashPageInitiated event,
+    Emitter<SplashState> emit,
+  ) async {
+    return runBlocCatching(
+      action: () async {
+        await Future<void>.delayed(DurationConstants.defaultSplashDuration);
+        final isLoggedIn =
+            _isLoggedInUseCase.execute(const IsLoggedInInput()).isLoggedIn;
+        await navigator.replace(
+          isLoggedIn ? const AppRouteInfo.main() : const AppRouteInfo.login(),
+        );
+      },
+      handleError: false,
+    );
+  }
+}

--- a/app/lib/ui/splash/bloc/splash_event.dart
+++ b/app/lib/ui/splash/bloc/splash_event.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../base/bloc/base_bloc_event.dart';
+
+part 'splash_event.freezed.dart';
+
+abstract class SplashEvent extends BaseBlocEvent {
+  const SplashEvent();
+}
+
+@freezed
+class SplashPageInitiated extends SplashEvent with _$SplashPageInitiated {
+  const factory SplashPageInitiated() = _SplashPageInitiated;
+}

--- a/app/lib/ui/splash/bloc/splash_state.dart
+++ b/app/lib/ui/splash/bloc/splash_state.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../base/bloc/base_bloc_state.dart';
+
+part 'splash_state.freezed.dart';
+
+@freezed
+class SplashState extends BaseBlocState with _$SplashState {
+  const factory SplashState() = _SplashState;
+}

--- a/app/lib/ui/splash/splash_page.dart
+++ b/app/lib/ui/splash/splash_page.dart
@@ -1,0 +1,47 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+import '../../app.dart';
+import 'package:shared/shared.dart';
+import 'bloc/splash.dart';
+
+@RoutePage()
+class SplashPage extends StatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends BasePageState<SplashPage, SplashBloc>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: DurationConstants.defaultSplashDuration,
+    )..repeat();
+    bloc.add(const SplashPageInitiated());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget buildPage(BuildContext context) {
+    return CommonScaffold(
+      body: Center(
+        child: RotationTransition(
+          turns: _controller,
+          child: const FlutterLogo(size: 100),
+        ),
+      ),
+    );
+  }
+}

--- a/domain/lib/src/entity/enum/enum.dart
+++ b/domain/lib/src/entity/enum/enum.dart
@@ -3,6 +3,7 @@ import 'package:resources/resources.dart';
 import 'package:shared/shared.dart';
 
 enum InitialAppRoute {
+  splash,
   login,
   main,
 }

--- a/domain/lib/src/navigation/app_route_info.dart
+++ b/domain/lib/src/navigation/app_route_info.dart
@@ -7,6 +7,7 @@ part 'app_route_info.freezed.dart';
 /// page
 @freezed
 class AppRouteInfo with _$AppRouteInfo {
+  const factory AppRouteInfo.splash() = _Splash;
   const factory AppRouteInfo.login() = _Login;
   const factory AppRouteInfo.main() = _Main;
   const factory AppRouteInfo.itemDetail(User user) = _UserDetail;

--- a/domain/lib/src/usecase/load_initial_resource_use_case.dart
+++ b/domain/lib/src/usecase/load_initial_resource_use_case.dart
@@ -15,9 +15,9 @@ class LoadInitialResourceUseCase
   @protected
   @override
   LoadInitialResourceOutput buildUseCase(LoadInitialResourceInput input) {
-    final initialRoutes = [_repository.isLoggedIn ? InitialAppRoute.main : InitialAppRoute.login];
-
-    return LoadInitialResourceOutput(initialRoutes: initialRoutes);
+    return const LoadInitialResourceOutput(
+      initialRoutes: [InitialAppRoute.splash],
+    );
   }
 }
 
@@ -31,6 +31,6 @@ class LoadInitialResourceOutput extends BaseOutput with _$LoadInitialResourceOut
   const LoadInitialResourceOutput._();
 
   const factory LoadInitialResourceOutput({
-    @Default([InitialAppRoute.main]) List<InitialAppRoute> initialRoutes,
+    @Default([InitialAppRoute.splash]) List<InitialAppRoute> initialRoutes,
   }) = _LoadInitialResourceOutput;
 }

--- a/shared/lib/src/constants/duration_constants.dart
+++ b/shared/lib/src/constants/duration_constants.dart
@@ -6,4 +6,5 @@ class DurationConstants {
   static const defaultGeneralDialogTransitionDuration = Duration(milliseconds: 200);
   static const defaultSnackBarDuration = Duration(seconds: 3);
   static const defaultErrorVisibleDuration = Duration(seconds: 3);
+  static const defaultSplashDuration = Duration(seconds: 3);
 }


### PR DESCRIPTION
## Summary
- add `SplashPage` with bloc and rotation animation
- route via `SplashRoute` that navigates to login/main after 3 seconds
- map new `InitialAppRoute.splash` in `LoadInitialResourceUseCase`
- export and register splash screen in router and mappers
- refine splash bloc to use `runBlocCatching`
- add `DurationConstants.defaultSplashDuration` and use it

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68843a180284832bbe8b952cd470bacd