### PR TITLE
Fix logout to clear stored token

### DIFF
--- a/domain/lib/src/usecase/logout_use_case.dart
+++ b/domain/lib/src/usecase/logout_use_case.dart
@@ -16,7 +16,7 @@ class LogoutUseCase extends BaseFutureUseCase<LogoutInput, LogoutOutput> {
   @override
   Future<LogoutOutput> buildUseCase(LogoutInput input) async {
     if (_repository.isLoggedIn) {
-      // await _repository.logout();
+      await _repository.logout();
       await _navigator.replace(const AppRouteInfo.login());
     }
 


### PR DESCRIPTION
## Summary
- ensure logout removes tokens by calling repository

## Testing
- `melos run test` *(fails: meta package version conflict with Flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688456c83b60832b8204201937d21f12