### PR TITLE
Add message timestamp and ordering

### DIFF
--- a/app/android/app/src/main/kotlin/jp/flutter/app/LocalMessageData.kt
+++ b/app/android/app/src/main/kotlin/jp/flutter/app/LocalMessageData.kt
@@ -2,5 +2,6 @@ package jp.flutter.app
 
 data class LocalMessageData(
     var id: Long = 0,
-    var text: String? = null
+    var text: String? = null,
+    var createdAt: Long? = null
 )

--- a/app/android/app/src/main/kotlin/jp/flutter/app/MyFirebaseMessagingService.kt
+++ b/app/android/app/src/main/kotlin/jp/flutter/app/MyFirebaseMessagingService.kt
@@ -19,7 +19,10 @@ class MyFirebaseMessagingService : FlutterFirebaseMessagingService() {
         val body = message.data["encryptedBody"] ?: message.notification?.body
 
         val db = DatabaseHelper(this).writableDatabase
-        val values = ContentValues().apply { put("text", body) }
+        val values = ContentValues().apply {
+            put("text", body)
+            put("created_at", System.currentTimeMillis())
+        }
         val id = db.insert("message", null, values)
 
         val cursor = db.rawQuery("SELECT COUNT(*) FROM message", null)

--- a/app/android/app/src/main/kotlin/jp/flutter/app/sqlite/DatabaseHelper.kt
+++ b/app/android/app/src/main/kotlin/jp/flutter/app/sqlite/DatabaseHelper.kt
@@ -11,7 +11,7 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(
     context,
     getDatabasePath(context),
     null,
-    1
+    2
 ) {
     companion object {
         private fun getDatabasePath(context: Context): String {
@@ -33,11 +33,13 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(
             "CREATE TABLE image_url(id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, origin TEXT, sm TEXT, md TEXT, lg TEXT, is_avatar INTEGER)"
         )
         db.execSQL(
-            "CREATE TABLE message(id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT)"
+            "CREATE TABLE message(id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT, created_at INTEGER)"
         )
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-        // handle migration if needed
+        if (oldVersion < 2) {
+            db.execSQL("ALTER TABLE message ADD COLUMN created_at INTEGER")
+        }
     }
 }

--- a/app/ios/NotificationService/NotificationService.swift
+++ b/app/ios/NotificationService/NotificationService.swift
@@ -1,4 +1,5 @@
 import UserNotifications
+import Flutter
 
 class NotificationService: UNNotificationServiceExtension {
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
@@ -8,6 +9,13 @@ class NotificationService: UNNotificationServiceExtension {
         }
 
         SqliteHelper.insertMessage(bestAttemptContent.body)
+
+        if let engine = FlutterEngineCache.default().engine(for: "main") {
+            DispatchQueue.main.async {
+                FlutterMethodChannel(name: "sync_channel", binaryMessenger: engine.binaryMessenger)
+                    .invokeMethod("dataUpdated", arguments: bestAttemptContent.body)
+            }
+        }
 
         contentHandler(bestAttemptContent)
     }

--- a/app/ios/NotificationService/SqliteHelper.swift
+++ b/app/ios/NotificationService/SqliteHelper.swift
@@ -11,7 +11,8 @@ enum SqliteHelper {
             if sqlite3_open(url.path, &db) != SQLITE_OK {
                 print("SQLite init error")
             } else {
-                sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS message(id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT)", nil, nil, nil)
+                sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS message(id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT, created_at INTEGER)", nil, nil, nil)
+                sqlite3_exec(db, "ALTER TABLE message ADD COLUMN created_at INTEGER", nil, nil, nil)
             }
         }
     }
@@ -19,12 +20,14 @@ enum SqliteHelper {
     static func insertMessage(_ text: String?) {
         ensureInitialized()
         var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, "INSERT INTO message(text) VALUES(?)", -1, &stmt, nil) == SQLITE_OK {
+        if sqlite3_prepare_v2(db, "INSERT INTO message(text, created_at) VALUES(?, ?)", -1, &stmt, nil) == SQLITE_OK {
             if let t = text {
                 sqlite3_bind_text(stmt, 1, t, -1, SQLITE_TRANSIENT)
             } else {
                 sqlite3_bind_null(stmt, 1)
             }
+            let now = Int64(Date().timeIntervalSince1970 * 1000)
+            sqlite3_bind_int64(stmt, 2, now)
             sqlite3_step(stmt)
         }
         sqlite3_finalize(stmt)

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -59,6 +59,7 @@ export 'resource/styles/app_themes.dart';
 export 'shared_view/app_text_field.dart';
 export 'ui/home/home_page.dart';
 export 'ui/item_detail/item_detail_page.dart';
+export 'ui/messages/messages_page.dart';
 export 'ui/splash/splash_page.dart';
 export 'ui/login/login_page.dart';
 export 'ui/main/main_page.dart';

--- a/app/lib/navigation/mapper/app_route_info_mapper.dart
+++ b/app/lib/navigation/mapper/app_route_info_mapper.dart
@@ -11,6 +11,7 @@ class AppRouteInfoMapper extends BaseRouteInfoMapper {
     return appRouteInfo.when(
       splash: () => const SplashRoute(),
       login: () => const LoginRoute(),
+      messages: () => const MessagesRoute(),
       main: () => const MainRoute(),
       itemDetail: (user) => ItemDetailRoute(user: user),
     );

--- a/app/lib/navigation/routes/app_router.dart
+++ b/app/lib/navigation/routes/app_router.dart
@@ -18,6 +18,7 @@ class AppRouter extends RootStackRouter {
   List<AutoRoute> get routes => [
         AutoRoute(page: SplashRoute.page, initial: true),
         AutoRoute(page: LoginRoute.page),
+        AutoRoute(page: MessagesRoute.page),
         AutoRoute(page: MainRoute.page, children: [
           AutoRoute(
             page: HomeTab.page,

--- a/app/lib/ui/home/bloc/home_bloc.dart
+++ b/app/lib/ui/home/bloc/home_bloc.dart
@@ -11,8 +11,6 @@ import 'home.dart';
 class HomeBloc extends BaseBloc<HomeEvent, HomeState> {
   HomeBloc(
     this._getUsersUseCase,
-    this._getMessagesUseCase,
-    this._loadMoreMessagesUseCase,
   ) : super(HomeState()) {
     on<HomePageInitiated>(
       _onHomePageInitiated,
@@ -29,19 +27,9 @@ class HomeBloc extends BaseBloc<HomeEvent, HomeState> {
       transformer: log(),
     );
 
-    on<MessagesLoadMore>(
-      _onMessagesLoadMore,
-      transformer: log(),
-    );
-
-    on<MessagesUpdated>(
-      _onMessagesUpdated,
-      transformer: log(),
-    );
   }
   final GetUsersUseCase _getUsersUseCase;
-  final GetMessagesUseCase _getMessagesUseCase;
-  final LoadMoreMessagesUseCase _loadMoreMessagesUseCase;
+
 
   FutureOr<void> _onHomePageInitiated(HomePageInitiated event, Emitter<HomeState> emit) async {
     await _getUsers(
@@ -51,10 +39,6 @@ class HomeBloc extends BaseBloc<HomeEvent, HomeState> {
       doOnSuccessOrError: () async => emit(state.copyWith(isShimmerLoading: false)),
     );
 
-    await _getMessages(
-      emit: emit,
-      isInitialLoad: true,
-    );
   }
 
   FutureOr<void> _onUserLoadMore(UserLoadMore event, Emitter<HomeState> emit) async {
@@ -64,12 +48,6 @@ class HomeBloc extends BaseBloc<HomeEvent, HomeState> {
     );
   }
 
-  FutureOr<void> _onMessagesLoadMore(MessagesLoadMore event, Emitter<HomeState> emit) async {
-    await _getMessages(
-      emit: emit,
-      isInitialLoad: false,
-    );
-  }
 
   FutureOr<void> _onHomePageRefreshed(HomePageRefreshed event, Emitter<HomeState> emit) async {
     await _getUsers(
@@ -108,26 +86,5 @@ class HomeBloc extends BaseBloc<HomeEvent, HomeState> {
     );
   }
 
-  Future<void> _getMessages({
-    required Emitter<HomeState> emit,
-    required bool isInitialLoad,
-  }) async {
-    return runBlocCatching(
-      action: () async {
-        final output = await (isInitialLoad
-            ? _getMessagesUseCase.execute(const GetMessagesInput(), true)
-            : _loadMoreMessagesUseCase.execute(const LoadMoreMessagesInput(), false));
-        emit(state.copyWith(messages: output));
-      },
-      handleLoading: false,
-    );
-  }
-
-  FutureOr<void> _onMessagesUpdated(
-    MessagesUpdated event,
-    Emitter<HomeState> emit,
-  ) async {
-    final list = [event.message, ...state.messages.data];
-    emit(state.copyWith(messages: state.messages.copyWith(data: list)));
-  }
+  
 }

--- a/app/lib/ui/home/bloc/home_event.dart
+++ b/app/lib/ui/home/bloc/home_event.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:domain/domain.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../../../base/bloc/base_bloc_event.dart';
@@ -28,12 +27,3 @@ class UserLoadMore extends HomeEvent with _$UserLoadMore {
   const factory UserLoadMore() = _UserLoadMore;
 }
 
-@freezed
-class MessagesLoadMore extends HomeEvent with _$MessagesLoadMore {
-  const factory MessagesLoadMore() = _MessagesLoadMore;
-}
-
-@freezed
-class MessagesUpdated extends HomeEvent with _$MessagesUpdated {
-  const factory MessagesUpdated(Message message) = _MessagesUpdated;
-}

--- a/app/lib/ui/home/bloc/home_state.dart
+++ b/app/lib/ui/home/bloc/home_state.dart
@@ -10,8 +10,6 @@ part 'home_state.freezed.dart';
 class HomeState extends BaseBlocState with _$HomeState {
   factory HomeState({
     @Default(LoadMoreOutput<User>(data: <User>[])) LoadMoreOutput<User> users,
-    @Default(LoadMoreOutput<Message>(data: <Message>[]))
-    LoadMoreOutput<Message> messages,
     @Default(false) bool isShimmerLoading,
     AppException? loadUsersException,
   }) = _HomeState;

--- a/app/lib/ui/messages/bloc/messages.dart
+++ b/app/lib/ui/messages/bloc/messages.dart
@@ -1,0 +1,3 @@
+export 'messages_bloc.dart';
+export 'messages_event.dart';
+export 'messages_state.dart';

--- a/app/lib/ui/messages/bloc/messages_bloc.dart
+++ b/app/lib/ui/messages/bloc/messages_bloc.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:domain/domain.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../app.dart';
+import 'messages.dart';
+
+@Injectable()
+class MessagesBloc extends BaseBloc<MessagesEvent, MessagesState> {
+  MessagesBloc(
+    this._getMessagesUseCase,
+    this._loadMoreMessagesUseCase,
+  ) : super(MessagesState()) {
+    on<MessagesPageInitiated>(
+      _onMessagesPageInitiated,
+      transformer: log(),
+    );
+    on<MessagesLoadMore>(
+      _onMessagesLoadMore,
+      transformer: log(),
+    );
+    on<MessagesUpdated>(
+      _onMessagesUpdated,
+      transformer: log(),
+    );
+  }
+
+  final GetMessagesUseCase _getMessagesUseCase;
+  final LoadMoreMessagesUseCase _loadMoreMessagesUseCase;
+
+  FutureOr<void> _onMessagesPageInitiated(
+    MessagesPageInitiated event,
+    Emitter<MessagesState> emit,
+  ) async {
+    await _getMessages(emit: emit, isInitialLoad: true);
+  }
+
+  FutureOr<void> _onMessagesLoadMore(
+    MessagesLoadMore event,
+    Emitter<MessagesState> emit,
+  ) async {
+    await _getMessages(emit: emit, isInitialLoad: false);
+  }
+
+  Future<void> _getMessages({
+    required Emitter<MessagesState> emit,
+    required bool isInitialLoad,
+  }) async {
+    return runBlocCatching(
+      action: () async {
+        final output = await (isInitialLoad
+            ? _getMessagesUseCase.execute(const GetMessagesInput(), true)
+            : _loadMoreMessagesUseCase.execute(
+                const LoadMoreMessagesInput(),
+                false,
+              ));
+        emit(state.copyWith(messages: output));
+      },
+      handleLoading: false,
+    );
+  }
+
+  FutureOr<void> _onMessagesUpdated(
+    MessagesUpdated event,
+    Emitter<MessagesState> emit,
+  ) async {
+    final list = [event.message, ...state.messages.data];
+    emit(state.copyWith(messages: state.messages.copyWith(data: list)));
+  }
+}

--- a/app/lib/ui/messages/bloc/messages_event.dart
+++ b/app/lib/ui/messages/bloc/messages_event.dart
@@ -1,0 +1,25 @@
+import 'package:domain/domain.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../base/bloc/base_bloc_event.dart';
+
+part 'messages_event.freezed.dart';
+
+abstract class MessagesEvent extends BaseBlocEvent {
+  const MessagesEvent();
+}
+
+@freezed
+class MessagesPageInitiated extends MessagesEvent with _$MessagesPageInitiated {
+  const factory MessagesPageInitiated() = _MessagesPageInitiated;
+}
+
+@freezed
+class MessagesLoadMore extends MessagesEvent with _$MessagesLoadMore {
+  const factory MessagesLoadMore() = _MessagesLoadMore;
+}
+
+@freezed
+class MessagesUpdated extends MessagesEvent with _$MessagesUpdated {
+  const factory MessagesUpdated(Message message) = _MessagesUpdated;
+}

--- a/app/lib/ui/messages/bloc/messages_state.dart
+++ b/app/lib/ui/messages/bloc/messages_state.dart
@@ -1,0 +1,15 @@
+import 'package:domain/domain.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:shared/shared.dart';
+
+import '../../../base/bloc/base_bloc_state.dart';
+
+part 'messages_state.freezed.dart';
+
+@freezed
+class MessagesState extends BaseBlocState with _$MessagesState {
+  factory MessagesState({
+    @Default(LoadMoreOutput<Message>(data: <Message>[]))
+    LoadMoreOutput<Message> messages,
+  }) = _MessagesState;
+}

--- a/app/lib/ui/messages/messages_page.dart
+++ b/app/lib/ui/messages/messages_page.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:domain/domain.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../app.dart';
+import 'bloc/messages.dart';
+import 'package:intl/intl.dart';
+
+@RoutePage()
+class MessagesPage extends StatefulWidget {
+  const MessagesPage({super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _MessagesPageState();
+  }
+}
+
+class _MessagesPageState extends BasePageState<MessagesPage, MessagesBloc> {
+  late final CommonPagingController<Message> _pagingController =
+      CommonPagingController<Message>()..disposeBy(disposeBag);
+  late final MethodChannel _channel;
+
+  @override
+  void initState() {
+    super.initState();
+    bloc.add(const MessagesPageInitiated());
+    _pagingController.listen(
+      onLoadMore: () => bloc.add(const MessagesLoadMore()),
+    );
+    _channel = const MethodChannel('sync_channel');
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'dataUpdated') {
+        final text = call.arguments as String?;
+        if (text != null) {
+          bloc.add(
+            MessagesUpdated(Message(text: text, createdAt: DateTime.now())),
+          );
+        }
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _channel.setMethodCallHandler(null);
+    _pagingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget buildPageListeners({required Widget child}) {
+    return BlocListener<MessagesBloc, MessagesState>(
+      listenWhen: (previous, current) => previous.messages != current.messages,
+      listener: (context, state) {
+        _pagingController.appendLoadMoreOutput(state.messages);
+      },
+      child: child,
+    );
+  }
+
+  @override
+  Widget buildPage(BuildContext context) {
+    return CommonScaffold(
+      appBar: CommonAppBar(
+        text: 'Messages',
+        leadingIcon: navigator.canPopSelfOrChildren
+            ? LeadingIcon.back
+            : LeadingIcon.none,
+        backgroundColor: AppColors.current.primaryColor,
+        titleTextStyle: AppTextStyles.s14w400Primary(),
+      ),
+      body: BlocBuilder<MessagesBloc, MessagesState>(
+        buildWhen: (previous, current) => previous.messages != current.messages,
+        builder: (context, state) {
+          return CommonPagedListView<Message>(
+            pagingController: _pagingController,
+            itemBuilder: (context, msg, index) => Padding(
+              padding: EdgeInsets.all(Dimens.d4.responsive()),
+              child: Text(
+                '${DateFormat.Hms().format(msg.createdAt ?? DateTime.now())} - ${msg.text}',
+                style: AppTextStyles.s14w400Primary(),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/data/lib/src/di/di.dart
+++ b/data/lib/src/di/di.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared/shared.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart';
+import 'repository/source/database/migration/migration_v2.dart';
 
 import 'di.config.dart';
 
@@ -22,7 +23,7 @@ abstract class ServiceModule {
     print('SQLite DB Path: $path');
     return openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: (db, version) async {
         await db.execute("CREATE TABLE user(\n"
             "id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
@@ -42,8 +43,12 @@ abstract class ServiceModule {
             ")");
         await db.execute("CREATE TABLE message(\n"
             "id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-            "text TEXT\n"
+            "text TEXT,\n"
+            "created_at INTEGER\n"
             ")");
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        await migrateV2(db, oldVersion);
       },
     );
   }

--- a/data/lib/src/repository/source/database/app_database.dart
+++ b/data/lib/src/repository/source/database/app_database.dart
@@ -96,8 +96,12 @@ class AppDatabase {
     required int limit,
   }) async {
     final offset = (page - 1) * limit;
-    final maps =
-        await database.query('message', limit: limit, offset: offset);
+    final maps = await database.query(
+      'message',
+      limit: limit,
+      offset: offset,
+      orderBy: 'created_at DESC',
+    );
     final items = maps.map(LocalMessageData.fromMap).toList();
     final next = items.length < limit ? null : page + 1;
     return PagedList(

--- a/data/lib/src/repository/source/database/mapper/local_message_data_mapper.dart
+++ b/data/lib/src/repository/source/database/mapper/local_message_data_mapper.dart
@@ -11,6 +11,9 @@ class LocalMessageDataMapper extends BaseDataMapper<LocalMessageData, Message>
     return Message(
       id: data?.id ?? 0,
       text: data?.text ?? '',
+      createdAt: data?.createdAt != null
+          ? DateTime.fromMillisecondsSinceEpoch(data!.createdAt!)
+          : Message.defaultCreatedAt,
     );
   }
 
@@ -19,6 +22,7 @@ class LocalMessageDataMapper extends BaseDataMapper<LocalMessageData, Message>
     return LocalMessageData(
       id: entity.id,
       text: entity.text,
+      createdAt: entity.createdAt?.millisecondsSinceEpoch,
     );
   }
 }

--- a/data/lib/src/repository/source/database/migration/migration_v2.dart
+++ b/data/lib/src/repository/source/database/migration/migration_v2.dart
@@ -1,0 +1,7 @@
+import 'package:sqflite/sqflite.dart';
+
+Future<void> migrateV2(Database db, int oldVersion) async {
+  if (oldVersion < 2) {
+    await db.execute('ALTER TABLE message ADD COLUMN created_at INTEGER');
+  }
+}

--- a/data/lib/src/repository/source/database/model/local_message_data.dart
+++ b/data/lib/src/repository/source/database/model/local_message_data.dart
@@ -1,16 +1,19 @@
 class LocalMessageData {
-  LocalMessageData({this.id = 0, this.text});
+  LocalMessageData({this.id = 0, this.text, this.createdAt});
 
   int id;
   String? text;
+  int? createdAt;
 
   Map<String, Object?> toMap() => {
         'id': id,
         'text': text,
+        'created_at': createdAt,
       };
 
   factory LocalMessageData.fromMap(Map<String, Object?> map) => LocalMessageData(
         id: map['id'] as int? ?? 0,
         text: map['text'] as String?,
+        createdAt: map['created_at'] as int?,
       );
 }

--- a/domain/lib/src/entity/message.dart
+++ b/domain/lib/src/entity/message.dart
@@ -7,5 +7,8 @@ class Message with _$Message {
   const factory Message({
     @Default(0) int id,
     @Default('') String text,
+    @Default(Message.defaultCreatedAt) DateTime? createdAt,
   }) = _Message;
+
+  static const DateTime? defaultCreatedAt = null;
 }

--- a/domain/lib/src/navigation/app_route_info.dart
+++ b/domain/lib/src/navigation/app_route_info.dart
@@ -9,6 +9,7 @@ part 'app_route_info.freezed.dart';
 class AppRouteInfo with _$AppRouteInfo {
   const factory AppRouteInfo.splash() = _Splash;
   const factory AppRouteInfo.login() = _Login;
+  const factory AppRouteInfo.messages() = _Messages;
   const factory AppRouteInfo.main() = _Main;
   const factory AppRouteInfo.itemDetail(User user) = _UserDetail;
 }


### PR DESCRIPTION
## Summary
- record message timestamp in SQLite on both Android and iOS
- expose timestamp in domain model and local mappers
- order message queries by newest first
- show message time in the home page list
- notify Flutter from iOS NotificationService
- provide database migration for timestamp column
- create dedicated MessagesPage for viewing messages
- move message UI from HomePage to new MessagesPage

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(failed: package not found)*
- `melos run build_domain` *(failed: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6886bc3454c8832bbddf05efad475e94