### PR TITLE
Add reply action to Android notifications

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,10 @@
             </intent-filter>
         </service>
 
+        <receiver
+            android:name=".NotificationReplyReceiver"
+            android:exported="false" />
+
         <!-- <meta-data
             android:name="com.secret.sdk"
             android:value="${apiKey}" /> -->

--- a/app/android/app/src/main/kotlin/jp/flutter/app/MyFirebaseMessagingService.kt
+++ b/app/android/app/src/main/kotlin/jp/flutter/app/MyFirebaseMessagingService.kt
@@ -3,12 +3,15 @@ package jp.flutter.app
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.ContentValues
+import android.content.Intent
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.RemoteInput
 import com.google.firebase.messaging.RemoteMessage
 import io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingService
 import io.flutter.embedding.engine.FlutterEngineCache
@@ -43,11 +46,35 @@ class MyFirebaseMessagingService : FlutterFirebaseMessagingService() {
             }
         }
 
+        val replyIntent = Intent(this, NotificationReplyReceiver::class.java).apply {
+            action = NotificationReplyReceiver.ACTION_REPLY
+        }
+        val replyPendingIntent = PendingIntent.getBroadcast(
+            this,
+            id.toInt(),
+            replyIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= 31) PendingIntent.FLAG_MUTABLE else 0
+        )
+
+        val remoteInput = RemoteInput.Builder(NotificationReplyReceiver.KEY_TEXT_REPLY)
+            .setLabel("Responder")
+            .build()
+
+        val replyAction = NotificationCompat.Action.Builder(
+            android.R.drawable.ic_menu_send,
+            "Responder",
+            replyPendingIntent
+        )
+            .addRemoteInput(remoteInput)
+            .setAllowGeneratedReplies(true)
+            .build()
+
         val builder = NotificationCompat.Builder(this, "default")
             .setContentTitle(message.notification?.title ?: "")
             .setContentText(body)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setAutoCancel(true)
+            .addAction(replyAction)
         if (NotificationManagerCompat.from(this).areNotificationsEnabled()) {
             NotificationManagerCompat.from(this).notify(id.toInt(), builder.build())
         } else {

--- a/app/android/app/src/main/kotlin/jp/flutter/app/NotificationReplyReceiver.kt
+++ b/app/android/app/src/main/kotlin/jp/flutter/app/NotificationReplyReceiver.kt
@@ -1,0 +1,53 @@
+package jp.flutter.app
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.ContentValues
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.RemoteInput
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.plugin.common.MethodChannel
+import jp.flutter.app.sqlite.DatabaseHelper
+
+class NotificationReplyReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (ACTION_REPLY == intent.action) {
+            val results = RemoteInput.getResultsFromIntent(intent)
+            val message = results?.getCharSequence(KEY_TEXT_REPLY)?.toString()
+            if (!message.isNullOrEmpty()) {
+                val db = DatabaseHelper(context).writableDatabase
+                val values = ContentValues().apply {
+                    put("text", message)
+                    put("created_at", System.currentTimeMillis())
+                }
+                val id = db.insert("message", null, values)
+
+                FlutterEngineCache.getInstance().get("main")?.let { engine ->
+                    Handler(Looper.getMainLooper()).post {
+                        MethodChannel(engine.dartExecutor.binaryMessenger, "sync_channel")
+                            .invokeMethod("dataUpdated", message)
+                    }
+                }
+
+                val confirmBuilder = NotificationCompat.Builder(context, "default")
+                    .setSmallIcon(android.R.drawable.ic_dialog_info)
+                    .setContentText(message)
+                    .setAutoCancel(true)
+                val notificationId = id.toInt()
+                if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+                    NotificationManagerCompat.from(context).notify(notificationId, confirmBuilder.build())
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_REPLY = "jp.flutter.app.ACTION_REPLY"
+        const val KEY_TEXT_REPLY = "KEY_TEXT_REPLY"
+    }
+}


### PR DESCRIPTION
## Summary
- add new `NotificationReplyReceiver` to save replies locally and notify Flutter via `MethodChannel`
- include a reply action in `MyFirebaseMessagingService`
- register the new receiver in Android manifest

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*
- `flutter test` *(fails: `command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_688709d3b5e4832b9aa5b49590b64838